### PR TITLE
dependency updates for dzil plugin issue on 5.8.8

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ Revision history for {{$dist->name}}
 {{$NEXT}}
           documentation fixes (Thanks, Gregor Herrmann of Debian!)
 
+          depend on at least version 0.17 of Class::Load, to work around a bug
+          with perl5.8.8 and Module::Runtime 0.012. (Karen Etheridge)
+
 2.200001  2011-02-11 11:13:20 America/New_York
           when throwing "package not installed", add a "package" attribute to
           Error

--- a/dist.ini
+++ b/dist.ini
@@ -8,6 +8,7 @@ Moose       = 0 ; min ver unknown
 Tie::IxHash = 0 ; min ver unknown
 Module::Pluggable::Object = 0 ; min ver unknown
 Test::More = 0.88
+Class::Load = 0.17
 
 [@RJBS]
 version = 2

--- a/lib/Config/MVP/Section.pm
+++ b/lib/Config/MVP/Section.pm
@@ -1,7 +1,7 @@
 package Config::MVP::Section;
 use Moose 0.91;
 
-use Class::Load 0.06 ();
+use Class::Load 0.17 ();
 use Config::MVP::Error;
 
 # ABSTRACT: one section of an MVP configuration sequence


### PR DESCRIPTION
Fixes Dist::Zilla test failure in t/diagnostics/plugin-fail.t: Class::Load <0.17 + Module::Runtime 0.012 = fail.
