### PR TITLE
Only dereference array references as array

### DIFF
--- a/lib/Config/MVP/Assembler/WithBundles.pm
+++ b/lib/Config/MVP/Assembler/WithBundles.pm
@@ -144,7 +144,7 @@ sub _add_bundle_contents {
       if (_HASHLIKE($payload)) {
         # XXX: Clearly this is a hack. -- rjbs, 2009-08-24
         for my $name (keys %$payload) {
-          my @v = ref $payload->{$name}
+          my @v = ref $payload->{$name} eq ref []
                 ? @{$payload->{$name}}
                 : $payload->{$name};
           Carp::confess("got impossible zero-value <$name> key")


### PR DESCRIPTION
This fixes https://github.com/rjbs/Config-MVP/issues/13 and will allow us to create Dist::Zilla plugins that can execute code, which would be an awesome way for bundles to delegate some stuff to a plugin because bundles have no access to the zilla object (https://github.com/rjbs/Dist-Zilla/issues/658).

```
has code => (
  is  => 'ro',
  isa => 'CodeRef',
  required => 1,
);

sub before_build {
    my ($self) = @_;

    $self->code->();
}
```